### PR TITLE
[FE] 스와이퍼 슬라이더 너비 오류 수정

### DIFF
--- a/front/src/components/LetterDetail/LetterPicture/LetterPictureWrapper.module.scss
+++ b/front/src/components/LetterDetail/LetterPicture/LetterPictureWrapper.module.scss
@@ -8,3 +8,6 @@
   padding: 1rem;
   width: 100%;
 }
+.slide {
+  width: auto !important;
+}

--- a/front/src/components/LetterDetail/LetterPicture/LetterPictureWrapper.tsx
+++ b/front/src/components/LetterDetail/LetterPicture/LetterPictureWrapper.tsx
@@ -3,6 +3,8 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 
 import styles from './LetterPictureWrapper.module.scss';
 import 'swiper/css';
+import 'swiper/css/scrollbar';
+import { Scrollbar } from 'swiper';
 
 type LetterPictureWrapperProps = {
   pictures: string[];
@@ -21,11 +23,17 @@ const LetterPictureWrapper = ({
 }: LetterPictureWrapperProps) => {
   return (
     <div className={styles.pictures}>
-      <Swiper spaceBetween={0} slidesPerView={4} className={styles.swiper}>
+      <Swiper
+        modules={[Scrollbar]}
+        spaceBetween={16}
+        slidesPerView={'auto'}
+        scrollbar={{ draggable: true }}
+        className={styles.swiper}
+      >
         {/* 이미지 key을 어떤 값으로 변경할지 */}
         {pictures.length > 0 &&
           pictures.map((picture, idx) => (
-            <SwiperSlide key={picture}>
+            <SwiperSlide key={picture} className={styles.slide}>
               <LetterPicture
                 pic={picture}
                 rotate={idx}
@@ -35,7 +43,7 @@ const LetterPictureWrapper = ({
           ))}
         {/* 글쓰기 모드 */}
         {!isRead && (
-          <SwiperSlide>
+          <SwiperSlide className={styles.slide}>
             <LetterPicture pic={''} isAdd rotate={1} onAdd={onAdd} />
           </SwiperSlide>
         )}

--- a/front/src/components/Main/RecomandUser/RecomandUserList.tsx
+++ b/front/src/components/Main/RecomandUser/RecomandUserList.tsx
@@ -15,7 +15,7 @@ const RecomandUserList = () => {
     <Swiper
       modules={[Navigation, Pagination, Scrollbar, A11y]}
       spaceBetween={16}
-      slidesPerView={5}
+      slidesPerView={'auto'}
       scrollbar={{ draggable: true }}
       onSwiper={(swiper) => console.log(swiper)}
       onSlideChange={() => console.log('slide change')}


### PR DESCRIPTION
## 문제
![image](https://user-images.githubusercontent.com/44540726/225797856-561b0e5d-c769-42ce-8e19-9b2bc80cb34a.png)
- 위와 같이 슬라이더가 뒤에 요소가 더 있는 데도 해당 태그를 보여주지 못하던 문제 수정

### 원인
- 슬라이더 화면에 보여질 요소 개수`slidesPerView`를 숫자로 지정하고 슬라이더 간의 거리 `spaceBetween`를 지정해주면 slide 바가 제대로 된 너비를 계산하지 못해서 발생하는 문제

### 해결 방법
```js
<Swiper
      modules={[Navigation, Pagination, Scrollbar, A11y]}
      spaceBetween={16}
      slidesPerView={'auto'}
      scrollbar={{ draggable: true }}
    >
```
`slidesPerView`를 `auto` 값으로 설정하는 경우 알아서 반응형으로 처리가 된다!