### PR TITLE
[FE] 편지 리스트 & 편지 유저 리스트 API 연결

### DIFF
--- a/front/src/components/Common/Empty/Empty.module.scss
+++ b/front/src/components/Common/Empty/Empty.module.scss
@@ -1,0 +1,16 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 50%;
+}
+
+.title {
+  color: var(--text-primary-color);
+  font-size: var(--font-size-xl);
+}
+
+.children {
+  margin-top: 1rem;
+}

--- a/front/src/components/Common/Empty/Empty.tsx
+++ b/front/src/components/Common/Empty/Empty.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+import styles from './Empty.module.scss';
+
+type EmptyProps = {
+  title?: string;
+  children?: ReactNode;
+};
+
+const Empty = ({ title, children }: EmptyProps) => {
+  return (
+    <div className={styles.wrapper}>
+      <h3 className={styles.title}>{title}</h3>
+      <div className={styles.children}>{children}</div>
+    </div>
+  );
+};
+
+export default Empty;

--- a/front/src/components/Common/UserCard/UserCard.tsx
+++ b/front/src/components/Common/UserCard/UserCard.tsx
@@ -3,7 +3,7 @@ import UserCardInfo from './UserCardInfo/UserCardInfo';
 
 import styles from './UserCard.module.scss';
 import { useSetRecoilState } from 'recoil';
-import { selectedUserInfo } from '../../../recoil/atoms';
+import { selectedUserInfoState } from '../../../recoil/atoms';
 import { LetterUserCardProps } from '../../Letter/LetterUserCard/LetterUserCard';
 import { useNavigate } from 'react-router-dom';
 import { LOCATION_CODE } from '../../../utils/enums/common/common.enum';
@@ -30,7 +30,7 @@ const UserCard = ({
   onClick,
 }: UserCardProps) => {
   const navigate = useNavigate();
-  const setUserInfo = useSetRecoilState(selectedUserInfo);
+  const setUserInfo = useSetRecoilState(selectedUserInfoState);
 
   const onClickHandler = () => {
     // 클릭 시, 편지 유저 페이지로 이동
@@ -39,6 +39,7 @@ const UserCard = ({
       birthday: birthday ? birthday : '',
       profile,
       location,
+      memberId,
     };
     setUserInfo(selectedUser);
     navigate(`/letters/${memberId}`);

--- a/front/src/components/Letter/Letter/Letter.tsx
+++ b/front/src/components/Letter/Letter/Letter.tsx
@@ -14,7 +14,6 @@ type LetterProps = {
   sender: string; // 보낸 사람
   receiver: string; // 받는 사람
   isRead: boolean; // 읽음 여부
-  canRead: boolean; // 읽을수 있는 여부
   hasPic: boolean; // 이미지 첨부 확인
   body: string; // 내용
   createdAt: string; // 편지 생성 날짜
@@ -50,10 +49,8 @@ const LetterStatus = ({ user, sender, isRead, hasPic }: LetterStatusProps) => {
 // 유저별 단일 카드 컴포넌트
 const Letter = ({
   sender,
-  receiver,
   body,
   isRead,
-  canRead,
   hasPic,
   createdAt,
   availableAt,
@@ -62,7 +59,7 @@ const Letter = ({
   const { user } = useAuth();
 
   // 편지 열람이 불가능한 경우
-  if (!canRead) {
+  if (!body) {
     return (
       <div className={`${styles.letter} ${styles.lock}`}>
         <div className={styles.open_time}>

--- a/front/src/components/Letter/LetterList.module.scss
+++ b/front/src/components/Letter/LetterList.module.scss
@@ -6,3 +6,8 @@
     margin-bottom: 0;
   }
 }
+
+.icon {
+  margin-top: 1rem;
+  color: var(--text-secondary-color);
+}

--- a/front/src/components/Letter/LetterList.tsx
+++ b/front/src/components/Letter/LetterList.tsx
@@ -37,12 +37,12 @@ const LetterList = () => {
 
   // 렌더링 시, 데이터 fetch
   const onClickHandler = (
-    e: React.MouseEvent<Element, MouseEvent>,
+    event: React.MouseEvent<Element, MouseEvent>,
     memberId: number,
     receiver: string
   ) => {
     // 이벤트 전파 방지
-    e.stopPropagation();
+    event.stopPropagation();
     setNewLetter((prev) => ({
       ...prev,
       memberId,

--- a/front/src/components/Letter/LetterList.tsx
+++ b/front/src/components/Letter/LetterList.tsx
@@ -51,6 +51,8 @@ const LetterList = () => {
         <UserCard
           key={user.memberId}
           {...user}
+          // TODO: 백엔드 수정까지 임시
+          birthday={String(new Date())}
           date={user.lastLetter.createdAt}
         >
           {/* UserCard에 사용할 아이콘을 children으로 전달 */}

--- a/front/src/components/Letter/LetterList.tsx
+++ b/front/src/components/Letter/LetterList.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 import { SlEnvolopeLetter } from 'react-icons/sl';
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { newLetterState } from '../../recoil/atoms';
 import { LetterUserData } from '../../utils';
 import { GET } from '../../utils/axios';
 import Empty from '../Common/Empty/Empty';
@@ -10,8 +13,10 @@ import styles from './LetterList.module.scss';
 // import { userData } from '../../dummy/userList';
 
 const LetterList = () => {
+  const setNewLetter = useSetRecoilState(newLetterState);
   const [userList, setUserList] = useState<LetterUserData[]>([]);
   const [page, setPage] = useState<number>(0);
+  const navigate = useNavigate();
 
   /**
    * @description API
@@ -31,10 +36,19 @@ const LetterList = () => {
   }, []);
 
   // 렌더링 시, 데이터 fetch
-  const onClickHandler = (e: React.MouseEvent<Element, MouseEvent>) => {
-    console.log('아이콘 클릭');
+  const onClickHandler = (
+    e: React.MouseEvent<Element, MouseEvent>,
+    memberId: number,
+    receiver: string
+  ) => {
     // 이벤트 전파 방지
     e.stopPropagation();
+    setNewLetter((prev) => ({
+      ...prev,
+      memberId,
+      receiver,
+    }));
+    navigate('/newLetter');
   };
 
   if (userList.length === 0) {
@@ -58,7 +72,9 @@ const LetterList = () => {
           {/* UserCard에 사용할 아이콘을 children으로 전달 */}
           <LetterStatusIcon
             status={user.lastLetter.status}
-            onClick={onClickHandler}
+            onClick={(event) => {
+              onClickHandler(event, user.memberId, user.name);
+            }}
             isRead={user.lastLetter.isRead}
           />
         </UserCard>

--- a/front/src/components/Letter/LetterList.tsx
+++ b/front/src/components/Letter/LetterList.tsx
@@ -1,13 +1,35 @@
+import { useEffect, useState } from 'react';
+import { SlEnvolopeLetter } from 'react-icons/sl';
 import { LetterUserData } from '../../utils';
-
+import { GET } from '../../utils/axios';
+import Empty from '../Common/Empty/Empty';
 import LetterStatusIcon from '../Common/LetterStatusIcon/LetterStatusIcon';
 import UserCard from '../Common/UserCard/UserCard';
 
-import { userData } from '../../dummy/userList';
-
 import styles from './LetterList.module.scss';
+// import { userData } from '../../dummy/userList';
 
 const LetterList = () => {
+  const [userList, setUserList] = useState<LetterUserData[]>([]);
+  const [page, setPage] = useState<number>(0);
+
+  /**
+   * @description API
+   */
+  const getLetterUserList = async () => {
+    try {
+      const { data } = await GET(`/letters?page=${page}&size=5`);
+      setUserList(data.content);
+    } catch (error) {
+      console.log('error');
+      // TODO: ERROR 처리 방법
+    }
+  };
+
+  useEffect(() => {
+    getLetterUserList();
+  }, []);
+
   // 렌더링 시, 데이터 fetch
   const onClickHandler = (e: React.MouseEvent<Element, MouseEvent>) => {
     console.log('아이콘 클릭');
@@ -15,9 +37,17 @@ const LetterList = () => {
     e.stopPropagation();
   };
 
+  if (userList.length === 0) {
+    return (
+      <Empty title="아직 편지를 교환한 사람이 없어요.">
+        <SlEnvolopeLetter className={styles.icon} size={'6rem'} />
+      </Empty>
+    );
+  }
+
   return (
     <ul className={styles.letter_list}>
-      {userData.map((user: LetterUserData) => (
+      {userList.map((user: LetterUserData) => (
         <UserCard
           key={user.memberId}
           {...user}

--- a/front/src/components/Letter/LetterList.tsx
+++ b/front/src/components/Letter/LetterList.tsx
@@ -65,8 +65,6 @@ const LetterList = () => {
         <UserCard
           key={user.memberId}
           {...user}
-          // TODO: 백엔드 수정까지 임시
-          birthday={String(new Date())}
           date={user.lastLetter.createdAt}
         >
           {/* UserCard에 사용할 아이콘을 children으로 전달 */}

--- a/front/src/components/Letter/LetterUserCard/LetterUserCard.module.scss
+++ b/front/src/components/Letter/LetterUserCard/LetterUserCard.module.scss
@@ -7,6 +7,9 @@ $sub-font-size: var(--font-size-sm);
   width: 100%;
   cursor: pointer;
 }
+.cursor {
+  cursor: default !important;
+}
 
 .usercard {
   display: flex;

--- a/front/src/components/Letter/LetterUserCard/LetterUserCard.tsx
+++ b/front/src/components/Letter/LetterUserCard/LetterUserCard.tsx
@@ -1,10 +1,12 @@
+import classNames from 'classnames';
+import { ko } from 'date-fns/locale';
 import { ReactComponent as ProfileIcon } from '../../../assets/img/user.svg';
 import { formatDateToMonth, getAge } from '../../../utils';
-import { ko } from 'date-fns/locale';
 import { LOCATION_CODE } from '../../../utils/enums/common/common.enum';
 import { locationTransformer } from '../../../utils/common';
 import RoundProfile from '../../Common/RoundProfile/RoundProfile';
 import styles from './LetterUserCard.module.scss';
+import { useNavigate } from 'react-router-dom';
 
 export type LetterUserCardProps = {
   birthday: string;
@@ -12,6 +14,7 @@ export type LetterUserCardProps = {
   name: string;
   profile: string | null;
   memberId: null | number;
+  cursor?: boolean;
 };
 
 const LetterUserCard = ({
@@ -20,15 +23,26 @@ const LetterUserCard = ({
   birthday,
   profile,
   memberId,
+  cursor = true,
 }: LetterUserCardProps) => {
+  const navigate = useNavigate();
+
   // 생년월일 계산
   const formatedDate = formatDateToMonth(new Date(birthday), ko);
 
   // 나이 계산
   const age = getAge(new Date(birthday));
 
+  const classNameValue = classNames(styles.wrapper, {
+    [styles.cursor]: !cursor,
+  });
+
+  const onClickHandler = () => {
+    navigate(`/profile/${memberId}`);
+  };
+
   return (
-    <div className={styles.wrapper}>
+    <div className={classNameValue}>
       <div className={styles.usercard}>
         <div className={styles.profile_img}>
           <RoundProfile location={location} profile={profile} />
@@ -40,7 +54,7 @@ const LetterUserCard = ({
           )} / ${formatedDate} / ${age}세`}</div>
         </div>
       </div>
-      <button className={styles.profile_button}>
+      <button className={styles.profile_button} onClick={onClickHandler}>
         <ProfileIcon />
       </button>
     </div>

--- a/front/src/components/Letter/LetterUserCard/LetterUserCard.tsx
+++ b/front/src/components/Letter/LetterUserCard/LetterUserCard.tsx
@@ -11,6 +11,7 @@ export type LetterUserCardProps = {
   location: LOCATION_CODE;
   name: string;
   profile: string | null;
+  memberId: null | number;
 };
 
 const LetterUserCard = ({
@@ -18,6 +19,7 @@ const LetterUserCard = ({
   name,
   birthday,
   profile,
+  memberId,
 }: LetterUserCardProps) => {
   // 생년월일 계산
   const formatedDate = formatDateToMonth(new Date(birthday), ko);

--- a/front/src/components/Letter/LetterWrapper/LetterWrapper.module.scss
+++ b/front/src/components/Letter/LetterWrapper/LetterWrapper.module.scss
@@ -5,3 +5,7 @@
   grid-template-rows: repeat(auto-fit, minmax(10rem, 1fr));
   gap: 1rem;
 }
+.icon {
+  margin-top: 1rem;
+  color: var(--text-secondary-color);
+}

--- a/front/src/components/Letter/LetterWrapper/LetterWrapper.tsx
+++ b/front/src/components/Letter/LetterWrapper/LetterWrapper.tsx
@@ -59,6 +59,7 @@ const LetterWrapper = () => {
         name={selectedUser.name}
         profile={selectedUser.profile}
         memberId={selectedUser.memberId}
+        cursor={false}
       />
       <div className={styles.letter_wrapper}>
         {userLetterList.map((letter) => (

--- a/front/src/components/Letter/LetterWrapper/LetterWrapper.tsx
+++ b/front/src/components/Letter/LetterWrapper/LetterWrapper.tsx
@@ -1,17 +1,33 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { selectedUserInfo } from '../../../recoil/atoms';
+import { selectedUserInfoState } from '../../../recoil/atoms';
+import { SlEnvolopeLetter } from 'react-icons/sl';
 import { useNavigate } from 'react-router-dom';
-
+import { GET } from '../../../utils/axios';
+import { LetterDataType } from '../../../utils';
 import Letter from '../Letter/Letter';
 import LetterUserCard from '../LetterUserCard/LetterUserCard';
+import Empty from '../../Common/Empty/Empty';
 
-import { lettersData } from '../../../dummy/letter';
 import styles from './LetterWrapper.module.scss';
+// import { lettersData } from '../../../dummy/letter';
 
 const LetterWrapper = () => {
   const navigate = useNavigate();
-  const selectedUser = useRecoilValue(selectedUserInfo);
+  const selectedUser = useRecoilValue(selectedUserInfoState);
+  const [page, setPage] = useState<number>(0);
+  const [userLetterList, setUserLetterList] = useState<LetterDataType[]>([]);
+
+  const getUserLetterList = async (memberId: number) => {
+    try {
+      // TODO: 페이지네이션 보류
+      const { data } = await GET(`letters/members/${memberId}`);
+      setUserLetterList(data.content);
+    } catch (error) {
+      console.log('error');
+      // TODO: ERROR 처리 방법
+    }
+  };
 
   useEffect(() => {
     // 리다이렉트
@@ -20,6 +36,21 @@ const LetterWrapper = () => {
     }
   }, []);
 
+  useEffect(() => {
+    if (!selectedUser.memberId) {
+      return;
+    }
+    getUserLetterList(selectedUser.memberId);
+  }, []);
+
+  if (userLetterList.length === 0) {
+    return (
+      <Empty title="아직 편지가 없어요.">
+        <SlEnvolopeLetter className={styles.icon} size={'6rem'} />
+      </Empty>
+    );
+  }
+
   return (
     <>
       <LetterUserCard
@@ -27,15 +58,15 @@ const LetterWrapper = () => {
         location={selectedUser.location}
         name={selectedUser.name}
         profile={selectedUser.profile}
+        memberId={selectedUser.memberId}
       />
       <div className={styles.letter_wrapper}>
-        {lettersData.map((letter) => (
+        {userLetterList.map((letter) => (
           <Letter
             sender={letter.sender.name}
             receiver={letter.receiver.name}
             body={letter.body}
             createdAt={letter.createdAt}
-            canRead={letter.canRead}
             hasPic={letter.hasPic}
             isRead={letter.isRead}
             key={letter.letterId}

--- a/front/src/dummy/letter.ts
+++ b/front/src/dummy/letter.ts
@@ -1,9 +1,9 @@
 import {
-  LetterData,
+  LetterDataType,
   SeletedLetterData,
 } from './../utils/types/letter/letter.type';
 
-export const lettersData: LetterData[] = [
+export const lettersData: LetterDataType[] = [
   {
     letterId: 1,
     sender: {
@@ -19,7 +19,6 @@ export const lettersData: LetterData[] = [
     ありがとうと君に言われるとなんだか切ないさようならの後も解けぬ魔法淡くほろ苦い友達でも恋人でもない中間地点で収穫の時を夢見てる青いフルーツあと一歩が踏み出せないせいで じれったいの何のって ありがとうと君に言われるとなんだか切ないさようならの後も解けぬ魔法淡くほろ苦い甘いだけの誘い文句味気のないTalkそんなものには興味をそそられない思い通りにいかない時だって人生捨てたもんじゃないって「どうしたの」と急に聞かれると「ううん、何でもない」さようならの後に消える笑顔私らしくない信じたいと願えば願うほどなんだか切ない「愛してるよ」よりも「大好き」の方が君らしいんじゃない忘れかけてた人の香りを突然思い出す頃降り積もる雪の白さをもっと素直に喜びたいよダイヤモンドよりも軟らかくて温かな未来手にしたいよ限りある時間を君と過ごした`,
     isRead: false,
     availableAt: '2023-03-12T11:12:01',
-    canRead: true,
     createdAt: '2023-02-28T19:12:01',
     hasPic: true,
   },
@@ -35,7 +34,6 @@ export const lettersData: LetterData[] = [
     },
     // title: 'test',
     isRead: true,
-    canRead: true,
     body: `ありがとうと君に言われると
 何だか切ないサヨナラの後も
 解けぬ魔法淡くほろ苦い
@@ -57,7 +55,6 @@ export const lettersData: LetterData[] = [
     },
     // title: 'test',
     isRead: true,
-    canRead: false,
     body: 'test',
     availableAt: '2023-03-12T12:12:01',
     createdAt: '2023-02-28T19:12:01',

--- a/front/src/recoil/atoms/letter/letter.ts
+++ b/front/src/recoil/atoms/letter/letter.ts
@@ -6,13 +6,14 @@ import { LetterUserCardProps } from './../../../components/Letter/LetterUserCard
 
 type selectedUserInfo = LetterUserCardProps;
 
-export const selectedUserInfo = atom<selectedUserInfo>({
-  key: 'selectedUserInfo',
+export const selectedUserInfoState = atom<selectedUserInfo>({
+  key: 'selectedUserInfoState',
   default: {
     birthday: String(new Date()),
     location: 'KR' as LOCATION_CODE,
     name: '',
     profile: '',
+    memberId: null,
   },
 });
 

--- a/front/src/recoil/atoms/letter/letter.ts
+++ b/front/src/recoil/atoms/letter/letter.ts
@@ -26,5 +26,6 @@ export const newLetterState = atom<newLetterType>({
     body: '',
     type: 0, // 일단 0으로 고정
     receiver: '',
+    memberId: null,
   },
 });

--- a/front/src/utils/axios/instanse.ts
+++ b/front/src/utils/axios/instanse.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-  baseURL: 'https://jsonplaceholder.typicode.com', // 기본 URL
-  // baseURL: process.env.REACT_APP_API_BASE_URL, // 기본 URL
+  baseURL: process.env.REACT_APP_BASE_URL,
   timeout: 5000, // 요청 타임아웃(ms)
   headers: {
     'Content-Type': 'application/json', // 요청 헤더
+    Authorization: process.env.REACT_APP_AUTH_TOKEN,
   },
+  withCredentials: true,
 });

--- a/front/src/utils/date/index.ts
+++ b/front/src/utils/date/index.ts
@@ -1,25 +1,37 @@
-import { differenceInMinutes, format, getYear, Locale, min } from 'date-fns';
+import { differenceInMinutes, format, getYear, Locale } from 'date-fns';
 
 /**
  * @description Date를 시간으로 변환하는 함수
  */
 export const formatDateToHour = (date: Date, locale: Locale): string => {
-  const result = format(date, 'aa h:m ', { locale });
-  return result;
+  try {
+    const result = format(date, 'aa h:m ', { locale });
+    return result;
+  } catch (error) {
+    return '';
+  }
 };
 
 /**
  * @description Date를 월/일로 변환하는 함수
  */
 export const formatDateToMonth = (date: Date, locale: Locale): string => {
-  return format(date, 'MMM do ', { locale });
+  try {
+    return format(date, 'MMM do ', { locale });
+  } catch (error) {
+    return '';
+  }
 };
 
 /**
  * @description 나이를 반환하는 함수
  */
 export const getAge = (date: Date): number => {
-  return getYear(new Date()) - getYear(date) + 1;
+  const result = getYear(new Date()) - getYear(date) + 1;
+  if (Number.isNaN(result)) {
+    return 0;
+  }
+  return result;
 };
 
 /**
@@ -29,6 +41,6 @@ export const getLetterOpenTime = (date: Date, nation: string): string => {
   const time = differenceInMinutes(new Date(), date);
   const hour = Math.floor(time / 60);
   const minute = time % 60;
-  // 문제: 언어별 처리를 어떻게 해야하는지 고민
+  // TODO: 언어별 처리를 어떻게 해야하는지 고민
   return `${hour}시간 ${minute}분후 도착`;
 };

--- a/front/src/utils/types/letter/letter.type.ts
+++ b/front/src/utils/types/letter/letter.type.ts
@@ -1,4 +1,4 @@
-export type LetterData = {
+export type LetterDataType = {
   letterId: number;
   sender: {
     memberId: number;
@@ -11,7 +11,6 @@ export type LetterData = {
   body: string;
   isRead: boolean; // 읽음 여부
   availableAt: string;
-  canRead: boolean;
   createdAt: string;
   hasPic: boolean; // 이미지 첨부 여부
 };

--- a/front/src/utils/types/letter/letter.type.ts
+++ b/front/src/utils/types/letter/letter.type.ts
@@ -35,4 +35,5 @@ export type newLetterType = {
   photoUrl: string[];
   type?: number;
   receiver: string;
+  memberId: null | number;
 };


### PR DESCRIPTION
## 기능
### 편지를 교환한 유저 리스트
![image](https://user-images.githubusercontent.com/44540726/225907272-43c7c85b-d9b3-4dc5-ba1c-c8938386860b.png)
- 프로필 클릭 시, 해당 유저와 교환한 편지를 확인하는 페이지로 이동
- 우측의 아이콘 클릭 시, 해당 유저에게 편지를 작성하는 페이지로 이동
- 페이지 접근 시, API를 호출해 리스트를 렌더링

### 특정 유저와 교환한 편지 리스트
![image](https://user-images.githubusercontent.com/44540726/225907539-b1753d79-69f3-4a5d-a8f1-71ec1739308b.png)
- 우측 `사람 icon`클릭 시, 해당 유저의 프로필 상세 페이지로 이동
- 페이지 접근 시, API를 호출해 리스트를 렌더링

### 공통 기능
![image](https://user-images.githubusercontent.com/44540726/225907890-8e121005-f2df-4efd-8620-f43176b537f6.png)
- 편지 & 유저 리스트가 없다면 `<Empty/>` 컴포넌트를 보여줌

### date 유틸 함수 에러 처리
Date에 잘못된 값이 들어간 경우 빈값으로 처리하도록 에러 처리