### PR TITLE
[FE] fix: receiverId 프로퍼티 명 변경

### DIFF
--- a/front/src/components/LetterDetail/NewLetterWrapper.tsx
+++ b/front/src/components/LetterDetail/NewLetterWrapper.tsx
@@ -24,7 +24,7 @@ const NewLetterWrapper = () => {
       const response = await POST(`/users/me/letters`, {
         body: letter.body,
         type: selectedLetterType,
-        receiver: letter.memberId,
+        receiverId: letter.memberId,
       });
       const location =
         response.headers.location && response.headers.location.split('/');


### PR DESCRIPTION
```
 const response = await POST(`/users/me/letters`, {
        body: letter.body,
        type: selectedLetterType,
        **receiverId**: letter.memberId,
      });
```
reciver -> receiverId 로 변경