### PR TITLE
[FE] feat: #213 메인 단어장 API 적용 & 추천친구리스트 CSS 및 출력 수 수정

### DIFF
--- a/front/src/components/Main/MainVoca/MainVocaCard.module.scss
+++ b/front/src/components/Main/MainVoca/MainVocaCard.module.scss
@@ -14,3 +14,16 @@
     line-height: 1.5;
   }
 }
+
+.empty {
+  padding: 1rem;
+  background-color: var(--white);
+  border-radius: var(--border-radius-sm);
+  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.05);
+  text-align: center;
+  p {
+    margin-bottom: 0.5rem;
+    color: var(--text-primary-color);
+    font-size: var(--font-size-sm);
+  }
+}

--- a/front/src/components/Main/MainVoca/MainVocaCard.tsx
+++ b/front/src/components/Main/MainVoca/MainVocaCard.tsx
@@ -1,15 +1,47 @@
+import { useState, useEffect } from 'react';
+import { GET } from '../../../utils/axios';
+import { VocaDataType } from '../../../utils/types/voca';
+import Button from '../../Common/Button/Button';
 import styles from './MainVocaCard.module.scss';
 
 const MainVocaCard = () => {
+  const [vocabs, sestVocabs] = useState<VocaDataType | null>(null);
+
+  const getVocabs = async () => {
+    try {
+      const { data } = await GET('/vocabs/random');
+      if (data) {
+        sestVocabs(data);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getVocabs();
+  }, []);
+
+  if (!vocabs) {
+    return (
+      <div className={styles.empty}>
+        <p>단어를 등록해주세요</p>
+        <Button variant="dashed" size="sm" to="/voca">
+          단어 추가
+        </Button>
+      </div>
+    );
+  }
+
   return (
-    <div className={styles.card}>
-      <h3>Apple</h3>
-      <p>
-        an apple pie
-        <br />
-        사과[애플]파이
-      </p>
-    </div>
+    <>
+      {vocabs && (
+        <div className={styles.card}>
+          <h3>{vocabs?.word}</h3>
+          <p>{vocabs?.meaning}</p>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/front/src/components/Main/RecomandUser/RecomandUserList.module.scss
+++ b/front/src/components/Main/RecomandUser/RecomandUserList.module.scss
@@ -5,6 +5,7 @@
   box-shadow: 0 0 1rem rgba(0, 0, 0, 0.05);
 
   .swiper_list {
+    padding-bottom: 1rem !important;
     .swiper_slide {
       width: auto !important;
     }

--- a/front/src/components/Main/RecomandUser/RecomandUserList.tsx
+++ b/front/src/components/Main/RecomandUser/RecomandUserList.tsx
@@ -13,7 +13,7 @@ const RecomandUserList = () => {
     try {
       const { data, status } = await GET('/users/me/recommend');
       if (status === 200 && data) {
-        setRecomandUserList(data.content);
+        setRecomandUserList(data.content.slice(0, 10));
       }
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## 개발내용
- 메인 단어장 API 적용

![image](https://user-images.githubusercontent.com/52031484/227707195-9c542da4-1d7f-472d-a6b6-84ddebcad0a2.png)

- 추천 친구 리스트 swiper 슬라이더 바 겹칩 css 수정 
![image](https://user-images.githubusercontent.com/52031484/227707166-cf09dfdc-ad06-45f6-bed6-513f7b08ffff.png)

- 추천 친구리스트 10명 노출
현재 페이지네이션이 적용된 API 에서 slice(0,10) 으로 10명만 노출 
-> 별도의 API로 작업할 것인지 논의 필요, 별도로 작업할 경우 기존의 API는 전체 추천리스트 친구 페이지로 만드는 쪽으로..
```
 const getRecomandUserList = async () => {
    try {
      const { data, status } = await GET('/users/me/recommend');
      if (status === 200 && data) {
        setRecomandUserList(data.content.slice(0, 10));
      }
    } catch (error) {
      console.error(error);
    }
  };
```
