### PR TITLE
[FE] fix: voca break-word css  수정

### DIFF
--- a/front/src/components/Main/MainVoca/MainVocaCard.module.scss
+++ b/front/src/components/Main/MainVoca/MainVocaCard.module.scss
@@ -7,10 +7,12 @@
     color: var(--text-primary-color);
     font-size: 1.25rem;
     font-weight: bold;
+    word-break: break-word;
   }
   p {
     margin-top: 1rem;
     color: var(--text-secondary-color);
     line-height: 1.5;
+    word-break: break-word;
   }
 }

--- a/front/src/components/Voca/VocaCard/VocaCard.module.scss
+++ b/front/src/components/Voca/VocaCard/VocaCard.module.scss
@@ -14,7 +14,7 @@
   font-weight: 700;
   color: var(--text-primary-color);
   margin-right: 0.8rem;
-  word-break: break-all;
+  word-break: break-word;
   white-space: pre-line;
   word-wrap: break-word;
   height: 100%;
@@ -23,7 +23,7 @@
   font-size: var(--font-size-sm);
   color: var(--text-secondary-color);
   flex: 1 1 0;
-  word-break: break-all;
+  word-break: break-word;
   white-space: pre-line;
   word-wrap: break-word;
   height: 100%;


### PR DESCRIPTION
- 단어장 word break css 수정
[변경전]
![image](https://user-images.githubusercontent.com/52031484/227708908-c3ac9cc9-5c23-4b78-83e8-046e909c764b.png)

[변경후]
![image](https://user-images.githubusercontent.com/52031484/227708889-d0e1f301-818b-42d5-b53d-828830f60f2d.png)


단순 css수정이라 바로 merge 하겠습니다
