### PR TITLE
[FE] fix: 라우터 유효하지 않은 토큰 쿠키 제거 및 replace 로 경로 변경 수정

### DIFF
--- a/front/src/utils/axios/instanse.ts
+++ b/front/src/utils/axios/instanse.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getCookie } from '../cookie';
+import { getCookie, removeCookie } from '../cookie';
 import { toast } from '../toast';
 
 export const instance = axios.create({
@@ -33,9 +33,8 @@ instance.interceptors.response.use(
       if (error.response.status === 401 && error.config) {
         toast.error('로그인에 실패하였습니다');
         if (window.location.pathname !== '/login') {
-          setTimeout(() => {
-            window.location.href = '/';
-          }, 1000);
+          removeCookie('accessJwtToken');
+          window.location.replace('/');
         }
         return;
       }


### PR DESCRIPTION
## 개발내용
- axios 401(권한없음) 에러시  쿠키에서 토큰 제거로직 추가
- location.href 에서 replace로 변경  
   => replace는 메서드로 작성하고 기존 페이지를 새로운 페이지로 변경하는 거라 history가 남지않음 (뒤로가기 이전 차단)

## 코드
```
instance.interceptors.response.use(
  (config) => {
    return config;
  },
  (error) => {
    return new Promise((resolve, reject) => {
      if (error.response.status === 401 && error.config) {
        toast.error('로그인에 실패하였습니다');
        if (window.location.pathname !== '/login') {
          removeCookie('accessJwtToken');
          window.location.replace('/');
        }
        return;
      }
      if (error.response.status === 404 && error.config) {
        toast.error(error.response.data.message || '요청에 실패하였습니다');
        return;
      }

      toast.error(error.response.data.message || '다시 시도해주세요');
      return reject(error);
    });
  }
);
```