### PR TITLE
[FE] 편지작성 버튼 노출 및 시간 관련 로직 수정

### DIFF
--- a/front/src/components/Letter/LetterList/LetterList.module.scss
+++ b/front/src/components/Letter/LetterList/LetterList.module.scss
@@ -1,5 +1,4 @@
 .letter_wrapper {
-  height: calc(100% - 15.75rem);
   margin-top: 0.875rem;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));

--- a/front/src/components/Profile/Profile.tsx
+++ b/front/src/components/Profile/Profile.tsx
@@ -303,20 +303,22 @@ const Profile = () => {
           </>
         )}
       </ProfileCard>
-      <Button
-        variant="primary"
-        size="md"
-        iconBtn
-        icon={<BiEdit />}
-        className={styles.btn_newLetter}
-        onClick={(event) => {
-          onClickHandler(
-            event,
-            userInfo?.memberId as number,
-            userInfo?.name as string
-          );
-        }}
-      />
+      {userInfo?.friend && (
+        <Button
+          variant="primary"
+          size="md"
+          iconBtn
+          icon={<BiEdit />}
+          className={styles.btn_newLetter}
+          onClick={(event) => {
+            onClickHandler(
+              event,
+              userInfo?.memberId as number,
+              userInfo?.name as string
+            );
+          }}
+        />
+      )}
     </>
   );
 };

--- a/front/src/utils/date/index.ts
+++ b/front/src/utils/date/index.ts
@@ -4,8 +4,13 @@ import { differenceInMinutes, format, getYear, Locale } from 'date-fns';
  * @description Date를 시간으로 변환하는 함수
  */
 export const formatDateToHour = (date: Date, locale: Locale): string => {
+  const diffTimeDate =
+    new Date(date).getTime() - date.getTimezoneOffset() * 60000;
+
   try {
-    const result = format(date, 'aa h:m ', { locale });
+    const result = format(new Date(diffTimeDate), 'aa hh:mm ', {
+      locale: locale,
+    });
     return result;
   } catch (error) {
     return '';

--- a/front/src/utils/date/index.ts
+++ b/front/src/utils/date/index.ts
@@ -8,7 +8,7 @@ export const formatDateToHour = (date: Date, locale: Locale): string => {
     new Date(date).getTime() - date.getTimezoneOffset() * 60000;
 
   try {
-    const result = format(new Date(diffTimeDate), 'aa hh:mm ', {
+    const result = format(diffTimeDate, 'aa hh:mm ', {
       locale: locale,
     });
     return result;


### PR DESCRIPTION
## 개발내용
- 친구 프로필 상세페이지에서 친구일때만 편지 작성 버튼 노출
- UTC시간 timezoneoffset 값으로 계산해서 보여주기
- 편지 리스트 관련 카드 형태 정렬 관련 css 수정 -> height 설정 값 제거

### 변경로직
- getTimezone을 추가하여 해당 서버 시간 보여주기

### 코드
```
export const formatDateToHour = (date: Date, locale: Locale): string => {
  const diffTimeDate =
    new Date(date).getTime() - date.getTimezoneOffset() * 60000;

  try {
    const result = format(new Date(diffTimeDate), 'aa hh:mm ', {
      locale: locale,
    });
    return result;
  } catch (error) {
    return '';
  }
};
```

### 결과
![image](https://user-images.githubusercontent.com/52031484/228446834-74c334c2-a325-4256-9c75-4f24edf895a6.png)

![image](https://user-images.githubusercontent.com/52031484/228446509-318245af-0428-45a7-b41d-c0a0c73c6bb7.png)
