### PR TITLE
[FE] 편지 카드 넓이&높이 수정 및 border radius 수정 

### DIFF
--- a/front/src/components/Common/UserCard/UserCard.module.scss
+++ b/front/src/components/Common/UserCard/UserCard.module.scss
@@ -6,6 +6,7 @@
   padding: 1rem 1.5rem;
   background-color: var(--white);
   cursor: pointer;
+  border-radius: var(--border-radius-sm);
 }
 .profile_img {
   margin-right: 1.5rem;

--- a/front/src/components/Letter/Letter/Letter.module.scss
+++ b/front/src/components/Letter/Letter/Letter.module.scss
@@ -1,8 +1,8 @@
 .letter {
   background-color: var(--white);
-  min-height: 10rem;
-  max-height: 10rem;
-  min-width: 10rem;
+  min-height: 11rem;
+  max-height: 11rem;
+  min-width: 11rem;
   padding: 1rem;
   font-size: var(--font-size-sm);
   display: flex;

--- a/front/src/components/Letter/Letter/Letter.module.scss
+++ b/front/src/components/Letter/Letter/Letter.module.scss
@@ -10,6 +10,7 @@
   justify-content: space-between;
   color: var(--text-primary-color);
   box-shadow: var(--default-box-shadow);
+  border-radius: var(--border-radius-sm);
 }
 
 .letter_status {

--- a/front/src/components/Letter/LetterList/LetterList.module.scss
+++ b/front/src/components/Letter/LetterList/LetterList.module.scss
@@ -1,8 +1,8 @@
 .letter_wrapper {
   margin-top: 0.875rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-  grid-template-rows: repeat(auto-fit, minmax(10rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  grid-template-rows: repeat(auto-fit, minmax(11rem, 1fr));
   gap: 1rem;
 }
 .icon {

--- a/front/src/components/Letter/LetterUserCard/LetterUserCard.module.scss
+++ b/front/src/components/Letter/LetterUserCard/LetterUserCard.module.scss
@@ -20,6 +20,8 @@ $sub-font-size: var(--font-size-sm);
   flex: 1 1 0;
   z-index: 1;
   justify-content: space-between;
+  border-top-left-radius: var(--border-radius-sm);
+  border-bottom-left-radius: var(--border-radius-sm);
 }
 .user_info {
   display: flex;
@@ -50,4 +52,6 @@ $sub-font-size: var(--font-size-sm);
   min-width: 3.75rem;
   background: $button_shadow;
   box-shadow: var(--default-box-shadow);
+  border-top-right-radius: var(--border-radius-sm);
+  border-bottom-right-radius: var(--border-radius-sm);
 }


### PR DESCRIPTION
## 개발내용
- 편지 카드 넓이&높이 수정 ->  데스크탑 사이즈에서 4개로 보이게 최소 넓이 높이 수정
- border radius 수정 

### 결과
- 변경 전
![image](https://user-images.githubusercontent.com/52031484/228474772-a13a9871-850d-4fa1-9b73-f41b6c1614f9.png)
- 변경 후
![image](https://user-images.githubusercontent.com/52031484/228474808-b8221950-4c50-43c3-92eb-fdade6e3bc22.png)
