### PR TITLE
[FE] 편지 작성 후, 뒤로가기 페이지가 다시 새 편지 작성 페이지가 아니도록 변경

### DIFF
--- a/front/src/components/LetterDetail/NewLetterWrapper.tsx
+++ b/front/src/components/LetterDetail/NewLetterWrapper.tsx
@@ -38,9 +38,11 @@ const NewLetterWrapper = () => {
       }));
 
       if (location[2]) {
-        navigate(`/letters/${newLetter.memberId}/${location[2]}`);
+        navigate(`/letters/${newLetter.memberId}/${location[2]}`, {
+          replace: true,
+        });
       } else {
-        navigate(`/letters/${newLetter.memberId}`);
+        navigate(`/letters/${newLetter.memberId}`, { replace: true });
       }
     } catch (error) {
       console.log('error');


### PR DESCRIPTION
## 개발 내용
편지 작성 후, 뒤로가기 페이지가 다시 새 편지 작성 페이지가 아니도록 변경

### 코드
```ts
      if (location[2]) {
        navigate(`/letters/${newLetter.memberId}/${location[2]}`, {
          replace: true,
        });
      } else {
        navigate(`/letters/${newLetter.memberId}`, { replace: true });
      }
```
- 편지 작성 후, 이동하는 링크를 replace로 변경