### PR TITLE
[FE] 검색 목록에서, 편지 보내는 UI 삭제 / 필요 없는 부분에 시간 UI 제거

### DIFF
--- a/front/src/components/BlackList/BlackList.tsx
+++ b/front/src/components/BlackList/BlackList.tsx
@@ -91,7 +91,7 @@ const BlackList = () => {
       {isAlertOpen && (
         <AlertModal
           labelClose="닫기"
-          labelSubmit="삭제"
+          labelSubmit="취소"
           onClose={() => {
             setIsAlertOpen(false);
           }}

--- a/front/src/components/Common/UserCard/NextUserCardList.tsx
+++ b/front/src/components/Common/UserCard/NextUserCardList.tsx
@@ -22,6 +22,7 @@ type NextUserCardListProps = {
     icon?: React.ReactNode;
     children?: React.ReactNode;
   };
+  date?: boolean;
 };
 
 type DataType = {
@@ -37,6 +38,7 @@ const NextUserCardList = ({
   endText,
   addRecentData,
   empty,
+  date,
 }: NextUserCardListProps) => {
   const data: DataType = useRecoilValue(selector);
   const [pagination, setPagination] = useRecoilState(pageNationState);
@@ -75,7 +77,7 @@ const NextUserCardList = ({
           location={user.location}
           profile={user.profile}
           birthday={user.birthday}
-          date={user.birthday}
+          date={date ? user.lastLetter.createdAt : null}
           onClick={onClick}
           memberStatus={user.memberStatus}
         >

--- a/front/src/components/Following/Following.tsx
+++ b/front/src/components/Following/Following.tsx
@@ -124,7 +124,7 @@ const Following = () => {
               <UserCard
                 key={user.memberId}
                 {...user}
-                date={user.lastLetter?.createdAt}
+                date={null}
                 onClick={moveProfileHandler}
               >
                 {/* UserCard에 사용할 아이콘을 children으로 전달 */}

--- a/front/src/components/Letter/LetterUserList/LetterUserList.tsx
+++ b/front/src/components/Letter/LetterUserList/LetterUserList.tsx
@@ -110,6 +110,7 @@ const LetterUserList = () => {
             addRecentData={addRecentData}
             empty={emptyProps}
             endText="마지막 스크롤 입니다."
+            date
           >
             <ChildrenButtonComponent />
           </NextUserCardList>

--- a/front/src/components/Search/SearchList/SearchList.tsx
+++ b/front/src/components/Search/SearchList/SearchList.tsx
@@ -3,9 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { RiEmotionSadLine } from 'react-icons/ri';
 import UserCard from '../../Common/UserCard/UserCard';
-import LetterStatusIcon from '../../Common/LetterStatusIcon/LetterStatusIcon';
 import {
-  newLetterState,
   searchUserListState,
   selectedSearchLangTagState,
   selectedSearchTagState,
@@ -21,7 +19,6 @@ import styles from './SearchList.module.scss';
 const SearchList = () => {
   const navigate = useNavigate();
   const userInfo = useRecoilValue(userState);
-  const setNewLetter = useSetRecoilState(newLetterState);
   const setPagination = useSetRecoilState(pageNationState);
   const [searchLangTags, setSearchLangTags] = useRecoilState(
     selectedSearchLangTagState
@@ -75,34 +72,6 @@ const SearchList = () => {
     navigate(`/profile/${id}`);
   };
 
-  const onClickHandler = (
-    event: React.MouseEvent<Element, MouseEvent>,
-    name: string,
-    memberId: number
-  ) => {
-    event.stopPropagation();
-    // 작성할 사람 이름 저장
-    navigate('/newletter');
-    setNewLetter((prev) => ({
-      ...prev,
-      receiver: name,
-      memberId,
-    }));
-  };
-
-  const ChildrenButtonComponent = ({ name, memberId }: any) => {
-    return (
-      <button
-        onClick={(event) => {
-          onClickHandler(event, name, memberId);
-        }}
-        className={styles.button}
-      >
-        <LetterStatusIcon status={'SENT'} isRead />
-      </button>
-    );
-  };
-
   const emptyProps = {
     title: '일치하는 유저가 없어요!',
     icon: <RiEmotionSadLine className={styles.icon} size={'6rem'} />,
@@ -119,9 +88,7 @@ const SearchList = () => {
           profile={user.profile}
           date={null}
           onClick={moveProfileHandler}
-        >
-          <ChildrenButtonComponent name={user.name} memberId={user.memberId} />
-        </UserCard>
+        ></UserCard>
       ))}
       {/* 새로 불러오는 List */}
       <Suspense fallback={<InnerSpinner size="sm" />}>
@@ -131,9 +98,7 @@ const SearchList = () => {
           empty={emptyProps}
           endText="마지막 스크롤 입니다."
           onClick={moveProfileHandler}
-        >
-          <ChildrenButtonComponent />
-        </NextUserCardList>
+        ></NextUserCardList>
       </Suspense>
     </ul>
   );


### PR DESCRIPTION
## 개발 내용
- 검색 목록에서, 편지 보내는 UI 삭제 / 필요 없는 부분에 시간 UI 제거
- 잘못 출력되던 시간 값 변경
### 스크린샷
![image](https://user-images.githubusercontent.com/44540726/228732050-a5e1fbe1-c036-4ddc-8b18-ac7b87397711.png)
- 마지막 편지의 시간 값이 아니라, 해당 데이터의 생성 시간을 보여주던 에러 수정

![image](https://user-images.githubusercontent.com/44540726/228732158-92c18da7-d565-43fe-8d13-1259ad1372ae.png)
- 친구 목록, 검색 기록등에 필요하지 않았던 시간이 표시되던 UI 수정


![image](https://user-images.githubusercontent.com/44540726/228732291-e56a3228-c6b8-47ca-8797-a3404b974653.png)
- 친구 차단 해제 모달의 문구 변경
