### PR TITLE
[FE] 메인 화면의 추천인이 새로고쳐지지않는 현상 수정

### DIFF
--- a/front/src/components/Main/RecomandUser/RecomandUserList.tsx
+++ b/front/src/components/Main/RecomandUser/RecomandUserList.tsx
@@ -3,11 +3,17 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import RecomandUserListItem from './RecomandUserListItem';
 import Button from '../../Common/Button/Button';
 import styles from './RecomandUserList.module.scss';
-import { useRecoilValue } from 'recoil';
+import { useRecoilRefresher_UNSTABLE, useRecoilValue } from 'recoil';
 import { recomandUserSelector } from '../../../recoil/selectors/user/user';
+import { useEffect } from 'react';
 
 const RecomandUserList = () => {
   const recomandUserList = useRecoilValue(recomandUserSelector);
+  const reset = useRecoilRefresher_UNSTABLE(recomandUserSelector);
+
+  useEffect(() => {
+    reset();
+  }, []);
 
   if (!recomandUserList.length) {
     return (

--- a/front/src/components/Main/RecomandUser/RecomandUserList.tsx
+++ b/front/src/components/Main/RecomandUser/RecomandUserList.tsx
@@ -1,11 +1,11 @@
+import { useEffect } from 'react';
+import { useRecoilRefresher_UNSTABLE, useRecoilValue } from 'recoil';
 import { Navigation, Pagination, Scrollbar, A11y } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import RecomandUserListItem from './RecomandUserListItem';
 import Button from '../../Common/Button/Button';
-import styles from './RecomandUserList.module.scss';
-import { useRecoilRefresher_UNSTABLE, useRecoilValue } from 'recoil';
 import { recomandUserSelector } from '../../../recoil/selectors/user/user';
-import { useEffect } from 'react';
+import styles from './RecomandUserList.module.scss';
 
 const RecomandUserList = () => {
   const recomandUserList = useRecoilValue(recomandUserSelector);


### PR DESCRIPTION
## 개발 내용
- 메인 화면의 추천인이 새로고쳐지지않는 현상 수정

### 내용
- 리코일 selector 사용 시, 같은 GET 요청의 데이터를 캐싱하면서 생기는 문제