### PR TITLE
[FE]  placeholder css 수정 및 생년월일 정규식, 필수 입력 체크, 로그아웃 relaod 수정

### DIFF
--- a/front/src/components/Common/InputFeild/InputFeild.tsx
+++ b/front/src/components/Common/InputFeild/InputFeild.tsx
@@ -8,6 +8,7 @@ type InputFeildProps = {
   pattern?: string;
   placeholder?: string;
   disabled?: boolean;
+  required?: boolean;
 };
 
 const InputFeild = ({
@@ -18,6 +19,7 @@ const InputFeild = ({
   placeholder,
   pattern,
   disabled,
+  required,
 }: InputFeildProps) => {
   return (
     <div className={styles.inputFeild}>
@@ -29,6 +31,7 @@ const InputFeild = ({
         placeholder={placeholder}
         pattern={pattern}
         disabled={disabled}
+        required={required}
       />
     </div>
   );

--- a/front/src/components/MyProfile/MyProfile.tsx
+++ b/front/src/components/MyProfile/MyProfile.tsx
@@ -301,7 +301,7 @@ const MyProfile = () => {
                               id="birthDay"
                               name="birthDay"
                               type="text"
-                              pattern="^(19[0-9][0-9]|20\d{2})-(0[0-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$"
+                              pattern="^(19[0-9][0-9]|20[0-1][0-9])-(0[0-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$"
                               placeholder="ex. 1989-12-24"
                               value={userInfo.birthday || ''}
                               required

--- a/front/src/components/MyProfile/MyProfile.tsx
+++ b/front/src/components/MyProfile/MyProfile.tsx
@@ -264,8 +264,9 @@ const MyProfile = () => {
                               id="name"
                               name="name"
                               type="text"
-                              placeholder="홍길동"
+                              placeholder="ex. 홍길동"
                               value={userInfo.name}
+                              required
                             />
                           </InfoGroup.Content>
                         </InfoGroup>
@@ -300,9 +301,10 @@ const MyProfile = () => {
                               id="birthDay"
                               name="birthDay"
                               type="text"
-                              pattern="^\d{4}-\d{2}-\d{2}$"
-                              placeholder="1989-12-24"
+                              pattern="^(19[0-9][0-9]|20\d{2})-(0[0-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$"
+                              placeholder="ex. 1989-12-24"
                               value={userInfo.birthday || ''}
+                              required
                             />
                           </InfoGroup.Content>
                         </InfoGroup>

--- a/front/src/context/AuthContext.tsx
+++ b/front/src/context/AuthContext.tsx
@@ -105,7 +105,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const logout = () => {
     resetState();
-    navigate('/', { replace: true });
+    window.location.replace('/');
   };
 
   const getToken = () => {

--- a/front/src/index.scss
+++ b/front/src/index.scss
@@ -137,6 +137,14 @@ button {
   height: 1px;
   margin: -1px;
 }
+
+input[type='text'],
+textarea {
+  &::placeholder {
+    color: #dcdcdc;
+  }
+}
+
 .inner_container {
   @include container;
 }


### PR DESCRIPTION
## 개발내용
- placeholder css 색상 수정 
- 프로필 생년월일 정규식 수정 (1900년이상 ~ 2020년이하 제한)
- 필수 입력 속성 추가
- 로그아웃시 window.reload.replace 로 변경 (새로고침 이슈)

### 코드
```
  <InputFeild
          id="birthDay"
          name="birthDay"
          type="text"
          pattern="^(19[0-9][0-9]|20[0-1][0-9])-(0[0-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$"
          placeholder="ex. 1989-12-24"
          value={userInfo.birthday || ''}
          required
        />
```